### PR TITLE
Fix devcontainer uv feature by switching to community-maintained version

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,7 @@
   "features": {
     "ghcr.io/devcontainers/features/common-utils:2": {},
     "ghcr.io/devcontainers/features/git:1": {},
-    "ghcr.io/devcontainers-contrib/features/uv:1": {},
+    "ghcr.io/va-h/devcontainers-features/uv:1": {},
     "ghcr.io/wandb/catnip/feature:0.1": {}
   },
   "customizations": {


### PR DESCRIPTION
## Summary

Replaced the non-functional `ghcr.io/devcontainers-contrib/features/uv:1` feature with the working community-maintained `ghcr.io/va-h/devcontainers-features/uv:1` feature in the devcontainer configuration.

## Context

The previous uv feature (`devcontainers-contrib`) was causing build failures with permission/access errors. After research, it was found that there is currently no official uv devcontainer feature from Astral (uv creators), but a reliable community alternative exists at `ghcr.io/va-h/devcontainers-features/uv`.

This change ensures the devcontainer can successfully build and provide uv tooling for Python development.