### PR TITLE
Fix Anki difficulty buttons showing prematurely on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -61,7 +61,7 @@
         <div class="flex gap-4 justify-center mt-8 flex-wrap max-[480px]:gap-2.5 max-[480px]:mt-5">
             <button class="px-6 py-4 border-0 rounded-[10px] text-base font-semibold cursor-pointer transition-all duration-300 min-w-[100px] bg-cyan-600 text-white hover:-translate-y-0.5 hover:shadow-[0_5px_15px_rgba(0,0,0,0.2)] max-[480px]:px-4 max-[480px]:py-3 max-[480px]:text-sm max-[480px]:min-w-[70px] max-[480px]:flex-1" id="showBtn" onclick="showAnswer()">Show Answer</button>
             
-            <div class="hidden gap-4 max-[480px]:grid max-[480px]:grid-cols-2 max-[480px]:gap-2.5 max-[480px]:w-full" id="gradeButtons">
+            <div class="hidden gap-4" id="gradeButtons">
                 <button class="px-6 py-4 border-0 rounded-[10px] text-base font-semibold cursor-pointer transition-all duration-300 min-w-[100px] bg-red-600 text-white hover:-translate-y-0.5 hover:shadow-[0_5px_15px_rgba(0,0,0,0.2)] max-[480px]:px-4 max-[480px]:py-3 max-[480px]:text-sm max-[480px]:min-w-[70px] max-[480px]:flex-1" onclick="gradeCard(0)">Again</button>
                 <button class="px-6 py-4 border-0 rounded-[10px] text-base font-semibold cursor-pointer transition-all duration-300 min-w-[100px] bg-orange-500 text-white hover:-translate-y-0.5 hover:shadow-[0_5px_15px_rgba(0,0,0,0.2)] max-[480px]:px-4 max-[480px]:py-3 max-[480px]:text-sm max-[480px]:min-w-[70px] max-[480px]:flex-1" onclick="gradeCard(1)">Hard</button>
                 <button class="px-6 py-4 border-0 rounded-[10px] text-base font-semibold cursor-pointer transition-all duration-300 min-w-[100px] bg-green-600 text-white hover:-translate-y-0.5 hover:shadow-[0_5px_15px_rgba(0,0,0,0.2)] max-[480px]:px-4 max-[480px]:py-3 max-[480px]:text-sm max-[480px]:min-w-[70px] max-[480px]:flex-1" onclick="gradeCard(2)">Good</button>
@@ -430,8 +430,11 @@
             document.getElementById('cardAnswer').classList.remove('hidden');
             document.getElementById('card').classList.add('flipped');
             document.getElementById('showBtn').classList.add('hidden');
-            document.getElementById('gradeButtons').classList.remove('hidden');
-            document.getElementById('gradeButtons').classList.add('flex');
+            const gradeButtons = document.getElementById('gradeButtons');
+            gradeButtons.classList.remove('hidden');
+            gradeButtons.classList.add('flex');
+            // Add mobile-specific classes when showing buttons
+            gradeButtons.classList.add('max-[480px]:grid', 'max-[480px]:grid-cols-2', 'max-[480px]:gap-2.5', 'max-[480px]:w-full');
             isShowingAnswer = true;
         }
 

--- a/index.html
+++ b/index.html
@@ -400,7 +400,9 @@
                 document.getElementById('cardContent').textContent = '🎉 All done for now!';
                 document.getElementById('cardAnswer').classList.add('hidden');
                 document.getElementById('showBtn').classList.add('hidden');
-                document.getElementById('gradeButtons').classList.add('hidden');
+                const gradeButtons = document.getElementById('gradeButtons');
+                gradeButtons.classList.add('hidden');
+                gradeButtons.classList.remove('flex', 'max-[480px]:grid', 'max-[480px]:grid-cols-2', 'max-[480px]:gap-2.5', 'max-[480px]:w-full');
                 return;
             }
 
@@ -420,7 +422,9 @@
             document.getElementById('card').classList.remove('flipped');
             
             document.getElementById('showBtn').classList.remove('hidden');
-            document.getElementById('gradeButtons').classList.add('hidden');
+            const gradeButtons = document.getElementById('gradeButtons');
+            gradeButtons.classList.add('hidden');
+            gradeButtons.classList.remove('flex', 'max-[480px]:grid', 'max-[480px]:grid-cols-2', 'max-[480px]:gap-2.5', 'max-[480px]:w-full');
             
             isShowingAnswer = false;
         }


### PR DESCRIPTION
## Summary

Fixed an issue where the Anki-style difficulty level buttons (Again, Hard, Good, Easy) were visible on mobile devices before the user clicked "Show Answer". This was breaking the intended flashcard flow where users should only see rating options after revealing the answer.

## Changes

The problem was caused by mobile-specific Tailwind CSS classes (`max-[480px]:grid`, etc.) that were overriding the `hidden` class on mobile viewports. The fix removes these classes from the initial HTML and instead dynamically adds them via JavaScript only when the answer is shown. This ensures the buttons remain properly hidden until needed, maintaining consistent behavior across all screen sizes.