### PR TITLE
Fix mobile layout spacing and reposition settings icon

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,10 +33,11 @@
     </style>
 </head>
 <body class="font-sans bg-gradient-main min-h-screen flex justify-center items-center p-5 overflow-hidden touch-none">
-    <button class="absolute top-5 right-5 bg-transparent border-0 text-2xl cursor-pointer transition-all p-1 hover:scale-125 hover:opacity-70" onclick="openSettings()">⚙️</button>
-    
-    <div class="bg-white rounded-[20px] shadow-[0_20px_40px_rgba(0,0,0,0.1)] max-w-[500px] w-full p-10 text-center max-h-screen overflow-y-auto overscroll-none">
-        <h1 class="text-gray-800 mb-8 text-3xl">🇷🇸 Cyrillinki</h1>
+    <div class="bg-white rounded-[20px] shadow-[0_20px_40px_rgba(0,0,0,0.1)] max-w-[500px] w-full p-10 text-center max-h-screen overflow-y-auto overscroll-none mt-8 safe-area-inset-top">
+        <div class="relative mb-8">
+            <h1 class="text-gray-800 text-3xl text-center">🇷🇸 Cyrillinki</h1>
+            <button class="absolute top-0 right-0 bg-transparent border-0 text-2xl cursor-pointer transition-all p-1 hover:scale-125 hover:opacity-70" onclick="openSettings()">⚙️</button>
+        </div>
         
         <div class="flex justify-around mb-8 p-5 bg-gray-100 rounded-[10px]">
             <div class="text-center">


### PR DESCRIPTION
## Summary

This PR addresses mobile layout issues where the settings icon was not visible and the top of the flashcard app was being cut off by the browser UI/status bar.

## Changes

- Moved the settings icon from an absolute position outside the card to inside the white card container
- Added top margin (`mt-8`) and safe area handling to prevent content from being hidden under mobile status bars
- Repositioned the settings icon using absolute positioning within a relative container to keep the "Cyrillinki" title perfectly centered

## Result

The app now displays correctly on mobile devices with proper spacing and all UI elements visible and accessible, while maintaining the clean centered layout of the title.